### PR TITLE
HtmlDocument.CreateComment without spaces

### DIFF
--- a/src/HtmlAgilityPack.Shared/HtmlDocument.cs
+++ b/src/HtmlAgilityPack.Shared/HtmlDocument.cs
@@ -503,7 +503,7 @@ namespace HtmlAgilityPack
 
             if (!comment.StartsWith("<!--") && !comment.EndsWith("-->"))
             {
-                comment = string.Concat("<!-- ", comment, " -->");
+                comment = "<!--" + comment + "-->";
             }
 
             HtmlCommentNode c = CreateComment();


### PR DESCRIPTION
Don't add spaces between the comment tokens `<!--`, `-->` and the comment.